### PR TITLE
为桌面文件添加StartupWMClass属性

### DIFF
--- a/en/guide/01-install.md
+++ b/en/guide/01-install.md
@@ -56,13 +56,13 @@ Create the desktop shortcut manually: create a file named `GUI.for.Clash.desktop
 Version=1.0
 Name=GUI.for.Clash
 Comment=GUI.for.Clash
+StartupWMClass=GUI.for.Clash
 Exec=/path/to/GUI.for.Clash/GUI.for.Clash
 Icon=/path/to/GUI.for.Clash/appicon.png
 Terminal=false
 Type=Application
 Categories=Application;GUI.for.Clash;
 StartupNotify=true
-
 ```
 
 ## 5. Directory Dissection

--- a/zh/guide/01-install.md
+++ b/zh/guide/01-install.md
@@ -55,6 +55,7 @@
 Version=1.0
 Name=GUI.for.Clash
 Comment=GUI.for.Clash
+StartupWMClass=GUI.for.Clash
 Exec=/path/to/GUI.for.Clash/GUI.for.Clash
 Icon=/path/to/GUI.for.Clash/appicon.png
 Terminal=false

--- a/zh/guide/01-install.md
+++ b/zh/guide/01-install.md
@@ -62,7 +62,6 @@ Terminal=false
 Type=Application
 Categories=Application;GUI.for.Clash;
 StartupNotify=true
-
 ```
 
 ## 5、目录详解


### PR DESCRIPTION
让gnome可以对窗口和桌面文件进行关联，进而可以在任务栏上显示软件图标